### PR TITLE
Chapter 12

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,61 @@
+class PasswordResetsController < ApplicationController
+  before_action :load_user, :valid_user, :check_expiration,
+                only: %i(edit update)
+
+  def new; end
+
+  def edit; end
+
+  def create
+    @user = User.find_by(email: params.dig(:password_reset, :email).downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = t(".password_reset_email_sent")
+      redirect_to root_url
+    else
+      flash.now[:danger] = t(".email_not_found")
+      render "new", status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if user_params[:password].empty?
+      @user.errors.add(:password, t(".password_can_not_be_blank"))
+      render :edit
+    elsif @user.update user_params
+      log_in @user
+      @user.update_columns reset_digest: nil
+      flash[:success] = t(".reset_password_successfully")
+      redirect_to @user
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit :password, :password_confirmation
+  end
+
+  def load_user
+    @user = User.find_by email: params[:email]
+    return if @user
+
+    flash[:danger] = t("password_resets.common.user_not_found")
+    redirect_to root_url
+  end
+
+  def valid_user
+    return if @user&.activated? && @user&.authenticated?(:reset, params[:id])
+
+    flash[:danger] = t("password_resets.common.user_is_not_activated")
+    redirect_to root_url
+  end
+
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = t("password_resets.common.password_reset_expired")
+    redirect_to new_password_reset_url
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['MAILER_DEFAULT_FROM']
+  default from: ENV["MAILER_DEFAULT_FROM"]
   layout "mailer"
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,9 +15,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def password_reset user
+    @user = user
+    mail to: user.email, subject: "Password reset"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
 
   has_secure_password
 
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   # Activates an account.
   def activate
@@ -41,6 +41,21 @@ class User < ApplicationRecord
     def new_token
       SecureRandom.urlsafe_base64
     end
+  end
+
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns reset_digest: User.digest(reset_token),
+                   reset_sent_at: Time.zone.now
+  end
+
+  # Sends password reset email.
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   # Remembers a user in the database for use in persistent sessions.

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,20 @@
+<% provide(:title, t(".title")) %>
+<h1><%= t(".reset_password") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(model: @user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password , t(".new_password") %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, t(".confirm_password") %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit t(".update_password"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, t(".title")) %>
+<h1><%= t(".forgot_password") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: password_resets_path, scope: :password_reset) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit t(".submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,6 +7,7 @@
         <%= f.label :email , t(".email") %>
         <%= f.email_field :email, class: "form-control" %>
         <%= f.label :password , t(".password") %>
+        <%= link_to t(".forgot_password"), new_password_reset_path %>
         <%= f.password_field :password, class: "form-control" %>
         <%= f.label :remember_me, class: "checkbox inline" do %>
           <%= f.check_box :remember_me %>

--- a/app/views/user_mailer/passwoord_reset.html.erb
+++ b/app/views/user_mailer/passwoord_reset.html.erb
@@ -1,0 +1,13 @@
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
+                                                      email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
+
+<p>
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,8 @@
+To reset your password click the link below:
+
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
       password: "Password"
       new_user: "New user?"
       signup_now: "Sign up now!"
+      forgot_password: "Forgot password?"
       remember_me_on_this_computer: "Remember me on this computer"
     create:
       invalid_email_password_combination: "Invalid email/password combination"
@@ -101,3 +102,27 @@ en:
     edit:
       invalid_activation_link: "Invalid activation link"
       account_activated: "Account activated!"
+
+  password_resets:
+    create:
+      password_reset_email_sent: "Email sent with password reset instructions"
+      email_not_found: "Email not found"
+    update:
+      password_can_not_be_blank: "Password can't be blank"
+      reset_password_successfully: "Password has been reset successfully"
+    edit: 
+      title: "Reset password"
+      reset_password: "Reset password"
+      new_password: "New password"
+      confirm_password: "Confirm password"
+      update_password: "Update password"
+    new:
+      title: "Forgot password"
+      forgot_password: "Forgot password"
+      email: "Email"
+      submit: "Submit"
+    common:
+      user_not_found: "User not found"
+      user_is_not_activated: "User is not activated"
+      password_reset_expired: "Password reset has expired"
+

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -73,6 +73,7 @@ vi:
       password: "Mật khẩu"
       new_user: "Người dùng mới?"
       signup_now: "Đăng ký ngay!"
+      forgot_password: "Quên mật khẩu?"
       remember_me_on_this_computer: "Ghi nhớ tài khoản trên máy tính này"
     create:
       invalid_email_password_combination: "Email/mật khẩu không hợp lệ"
@@ -97,3 +98,27 @@ vi:
       hello: "Xin chào"
       click_link: "Chào mừng bạn đến với ứng dụng mẫu! Nhấp vào liên kết bên dưới để kích hoạt tài khoản của bạn:"
       activate: "Kích hoạt tài khoản"
+  
+  account_activations:
+    edit:
+    invalid_activation_link: "Liên kết kích hoạt không hợp lệ"
+    account_activated: "Tài khoản đã được kích hoạt!"
+
+  password_resets:
+    create:
+      password_reset_email_sent: "Email đã được gửi với hướng dẫn đặt lại mật khẩu"
+      email_not_found: "Email không tồn tại"
+    update:
+      password_can_not_be_blank: "Mật khẩu không được để trống"
+      reset_password_successfully: "Mật khẩu đã được đặt lại thành công"
+    edit: 
+      title: "Đặt lại mật khẩu"
+      reset_password: "Đặt lại mật khẩu"
+      new_password: "Mật khẩu mới"
+      confirm_password: "Xác nhận mật khẩu"
+      update_password: "Cập nhật mật khẩu"
+    common:
+      user_not_found: "Người dùng không tồn tại"
+      user_is_not_activated: "Người dùng chưa được kích hoạt"
+      password_reset_expired: "Quá trình đặt lại mật khẩu đã hết hạn"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     post "/signup", to: "users#create"
     resources :users, only: [:show, :index, :edit, :update, :destroy]
     resources :account_activations, only: :edit
+    resources :password_resets, only: %i(new create edit update)
 
     get "/login", to: "sessions#new"
     post "/login", to: "sessions#create"

--- a/db/migrate/20230827062855_add_reset_to_users.rb
+++ b/db/migrate/20230827062855_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_25_023235) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_27_062855) do
   create_table "products", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -28,6 +28,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_023235) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
- **So sánh destroy và delete**
   - Destroy:

       - Phương thức destroy là một phương thức được cung cấp bởi Rails cho các đối tượng ActiveRecord. Nó dùng để xóa một đối tượng khỏi cơ sở dữ liệu cũng như kích hoạt các callback và xử lý liên quan đến việc xóa đối tượng.
       - Khi bạn gọi destroy trên một đối tượng, Rails sẽ gọi các callback như before_destroy, thực hiện xóa đối tượng khỏi cơ sở dữ liệu và sau đó gọi các callback after_destroy.
   - Delete:

       - Phương thức delete cũng được cung cấp bởi Rails cho các đối tượng ActiveRecord. Khi bạn gọi delete trên một đối tượng, nó sẽ xóa đối tượng khỏi cơ sở dữ liệu mà không kích hoạt bất kỳ callback nào.
       - Phương thức delete không thực hiện bất kỳ xử lý nào liên quan đến việc xóa hoặc giảm bớt các mối quan hệ của đối tượng.