### PR TITLE
Chapter14

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -71,6 +71,44 @@ aside{
   margin-top: 15px;
 }
 
+.stats {
+  overflow: auto;
+  margin-top: 0;
+  padding: 0;
+  a {
+    float: left;
+    padding: 0 10px;
+    border-left: 1px solid $gray-lighter;
+    color: gray;
+    &:first-child {
+      padding-left: 0;
+      border: 0;
+    }
+    &:hover {
+      text-decoration: none;
+      color: blue;
+    }
+  }
+  strong {
+    display: block;
+  }
+}
+
+.user_avatars {
+  overflow: auto;
+  margin-top: 10px;
+  .gravatar {
+    margin: 1px 1px;
+  }
+  a {
+    padding: 0;
+  }
+}
+
+.users.follow {
+  padding: 0;
+}
+
 
 /* forms */
 input, textarea, select, .uneditable-input {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,4 +20,12 @@ class ApplicationController < ActionController::Base
     flash[:danger] = t("users.common.please_log_in")
     redirect_to login_url, status: :see_other
   end
+
+  def find_user
+    @user = User.find_by id: params[:id]
+    return if @user
+
+    flash[:warning] = t("users.common.user_not_found")
+    redirect_to root_path
+  end
 end

--- a/app/controllers/followers_controller.rb
+++ b/app/controllers/followers_controller.rb
@@ -1,0 +1,10 @@
+class FollowersController < ApplicationController
+  before_action :logged_in_user, :find_user, only: :index
+
+  def index
+    @title = t(".followers")
+    @pagy, @users = pagy @user.followers,
+                         items: Settings.configs.pagy.user_per_page
+    render "users/show_follow"
+  end
+end

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -1,0 +1,10 @@
+class FollowingsController < ApplicationController
+  before_action :logged_in_user, :find_user, only: :index
+
+  def index
+    @title = t(".following")
+    @pagy, @users = pagy @user.following,
+                         items: Settings.configs.pagy.user_per_page
+    render "users/show_follow"
+  end
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,44 @@
+class RelationshipsController < ApplicationController
+  before_action :logged_in_user
+  before_action :load_user, only: :create
+  before_action :load_relationship, only: :destroy
+
+  def create
+    @user = User.find_by id: params[:followed_id]
+    return unless @user
+
+    current_user.follow(@user)
+    respond_to do |format|
+      format.html{redirect_to @user}
+      format.turbo_stream
+    end
+  end
+
+  def destroy
+    @user = Relationship.find(params[:id]).followed
+    return unless @user
+    current_user.unfollow(@user)
+    respond_to do |format|
+      format.html{redirect_to @user, status: :see_other}
+      format.turbo_stream
+    end
+  end
+
+  private
+
+  def load_user
+    @user = User.find_by id: params[:followed_id]
+    return if @user
+
+    flash[:danger] = t("relationships.common.user_not_found")
+    redirect_to root_path
+  end
+
+  def load_relationship
+    @user = Relationship.find_by(id: params[:id]).followed
+    return if @user
+
+    flash[:danger] = t("relationships.common.relationship_not_found")
+    redirect_to root_path
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: %i(index edit update destroy)
+  before_action :logged_in_user, except: %i(show new create)
   before_action :find_user, except: %i(index new create)
   before_action :correct_user, only: %i(edit update)
   before_action :admin_user, only: :destroy

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -5,13 +5,21 @@ class Micropost < ApplicationRecord
   end
 
   validates :content, presence: true,
-length: {maximum: Settings.validates.micropost.content.max_length}
+                      length: {
+                        maximum: Settings.validates.micropost.content.max_length
+                      }
   validates :image,
-            content_type: {in: Settings.configs.image.accept_type.split(", ").map(&:strip),
-                           message: I18n.t("microposts.validate.image_valid_format")},
-                              size: {less_than: 5.megabytes,
-                                     message: I18n.t("microposts.validate.less_than_5MB")}
-  scope :newest, ->{order created_at: :desc}
+            content_type: {
+              in: Settings.configs.image.accept_type.split(", ").map(&:strip),
+              message: I18n.t("microposts.validate.image_valid_format")
+            },
+            size: {
+              less_than: 5.megabytes,
+              message: I18n.t("microposts.validate.less_than_5MB")
+            }
+
+  scope :newest, ->{order(created_at: :desc)}
+  scope :related_posts, ->(user_id){where(user_id:)}
 
   delegate :name, to: :user, prefix: true
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: User.name
+  belongs_to :followed, class_name: User.name
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,15 @@ class User < ApplicationRecord
   before_create :create_activation_digest
 
   has_many :microposts, dependent: :destroy
+  has_many :active_relationships, class_name: Relationship.name,
+    foreign_key: :follower_id, dependent: :destroy
+  has_many :passive_relationships, class_name: Relationship.name,
+    foreign_key: :followed_id, dependent: :destroy
+
+  has_many :following, through: :active_relationships,
+    source: :followed
+  has_many :followers, through: :passive_relationships,
+    source: :follower
 
   validates :name, presence: true,
     length: {maximum: Settings.validates.name.length.max}
@@ -19,7 +28,22 @@ class User < ApplicationRecord
   attr_accessor :remember_token, :activation_token, :reset_token
 
   def feed
-    microposts.newest
+    Micropost.related_posts(following_ids << id).newest
+  end
+
+  # Follows a user.
+  def follow other_user
+    following << other_user
+  end
+
+  # Unfollows a user.
+  def unfollow other_user
+    following.delete other_user
+  end
+
+  # Returns true if the current user is following the other user.
+  def following? other_user
+    following.include? other_user
   end
 
   # Activates an account.

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -4,15 +4,15 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_with(model: @user, url: password_reset_path(params[:id])) do |f| %>
-      <%= render 'shared/error_messages' %>
+      <%= render "shared/error_messages" %>
 
       <%= hidden_field_tag :email, @user.email %>
 
       <%= f.label :password , t(".new_password") %>
-      <%= f.password_field :password, class: 'form-control' %>
+      <%= f.password_field :password, class: "form-control" %>
 
       <%= f.label :password_confirmation, t(".confirm_password") %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
 
       <%= f.submit t(".update_password"), class: "btn btn-primary" %>
     <% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -5,7 +5,7 @@
   <div class="col-md-6 col-md-offset-3">
     <%= form_with(url: password_resets_path, scope: :password_reset) do |f| %>
       <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
+      <%= f.email_field :email, class: "form-control" %>
 
       <%= f.submit t(".submit"), class: "btn btn-primary" %>
     <% end %>

--- a/app/views/relationships/create.turbo_stream.erb
+++ b/app/views/relationships/create.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.update "follow_form" do %>
+   <%= render partial: "users/unfollow" %>
+<% end %>
+<%= turbo_stream.update "followers" do %>
+   <%= @user.followers.count
+%> <% end %>

--- a/app/views/relationships/destroy.turbo_stream.erb
+++ b/app/views/relationships/destroy.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.update "follow_form" do %>
+   <%= render partial: "users/follow" %>
+<% end %>
+<%= turbo_stream.update "followers" do %>
+   <%= @user.followers.count %>
+<% end %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,0 +1,15 @@
+<% @user ||= current_user %>
+<div class="stats">
+  <a href="<%= followings_user_path(@user) %>">
+    <strong id="following" class="stat">
+      <%= @user.following.count %>
+    </strong>
+    <%= t(".following") %>
+  </a>
+  <a href="<%= followers_user_path(@user) %>">
+    <strong id="followers" class="stat">
+      <%= @user.followers.count %>
+    </strong>
+    <%= t(".followers") %>
+  </a>
+</div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -5,6 +5,9 @@
       <section class="user_info">
         <%= render "shared/user_info" %>
       </section>
+      <section class="stats">
+         <%= render "shared/stats" %>
+       </section>
       <section class="micropost_form">
         <%= render "shared/micropost_form" %>
       </section>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.active_relationships.build) do |f| %>
+  <div><%= hidden_field_tag :followed_id, @user.id %></div>
+  <%= f.submit t(".follow"), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,9 @@
+<% unless current_user?(@user) %>
+   <div id="follow_form">
+   <% if current_user.following?(@user) %>
+     <%= render "unfollow" %>
+   <% else %>
+     <%= render "follow" %>
+   <% end %>
+   </div>
+<% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.active_relationships.find_by(followed: @user),
+              html: { method: :delete }) do |f| %>
+   <%= f.submit "Unfollow", class: "btn" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,9 +7,13 @@
         <%= @user.name %>
       </h1>
     </section>
+    <section class="stats">
+      <%= render "shared/stats" %>
+    </section>
   </aside>
   
   <div class="col-md-8">
+    <%= render "follow_form" if logged_in? %>
     <% if @user.microposts.any? %>
       <h3><%= t(".microposts") %> (<%= @user.microposts.count %>)</h3>
       <ol class="microposts">

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,0 +1,30 @@
+<% provide(:title, @title) %>
+<div class="row">
+   <aside class="col-md-4">
+     <section class="user_info">
+       <%= gravatar_for @user %>
+       <h1><%= @user.name %></h1>
+       <span><%= link_to t(".view_profile"), @user %></span>
+       <span><strong><%= t(".microposts") %>:</strong> <%= @user.microposts.count %></span>
+     </section>
+     <section class="stats">
+       <%= render "shared/stats" %>
+       <% if @users.any? %>
+         <div class="user_avatars">
+           <% @users.each do |user| %>
+             <%= link_to gravatar_for(user, size: 30), user %>
+           <% end %>
+         </div>
+       <% end %>
+     </section>
+   </aside>
+   <div class="col-md-8">
+     <h3><%= @title %></h3>
+     <% if @users.any? %>
+       <ul class="users follow">
+         <%= render @users %>
+       </ul>
+       <%= pagy_bootstrap_nav(@pagy) %>
+     <% end %>
+   </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,13 @@ en:
       user_deleted_failed: "User deleted failed"
     create:
       check_your_email: "Please check your email to activate your account."
+    following:
+      title: "Following"
+    follow:
+      follow: "Follow"
+    show_follow:
+      microposts: "Microposts"
+      view_profile: "View profile"
     common:
       user_not_found: "User not found"
       wrong_user: "You are not authorized to edit this user"
@@ -73,6 +80,10 @@ en:
       post: "Post"
     user_info:
       view_my_profile: "View my profile"
+    stats:
+      following: "following"
+      followers: "followers"
+      microposts: "microposts"
   
   sessions:
     new:
@@ -152,3 +163,18 @@ en:
       image_valid_format: "Image must be a valid format"
       less_than_5MB: "Image must be less than 5MB"
       chose_other_image: "Maximum file size is 5MB. Please choose a smaller file."
+
+  relationships:
+    common:
+      user_not_found: "User not found"
+      relationship_not_found: "Relationship not found"
+
+  followers:
+    index:
+      title: "Followers"
+      followers: "Followers"
+  
+  followings:
+    index:
+      title: "Following"
+      following: "Following"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -40,6 +40,13 @@ vi:
       user_deleted_failed: "Xóa người dùng không thành công"
     create:
       check_your_email: "Vui lòng kiểm tra email của bạn để kích hoạt tài khoản."
+    following:
+      title: "Đang theo dõi"
+    follow:
+      follow: "Theo dõi"
+    show_follow:
+      microposts: "Bài viết"
+      view_profile: "Xem hồ sơ"
     common:
       user_not_found: "Không tìm thấy người dùng"
       wrong_user: "Bạn không được phép chỉnh sửa người dùng này"
@@ -73,6 +80,10 @@ vi:
       post: "Đăng"
     user_info:
       view_my_profile: "Xem hồ sơ của tôi"
+    stats:
+      following: "Người đang theo dõi"
+      followers: "Người theo dõi"
+      microposts: "Bài viết"
 
   sessions:
     new:
@@ -148,3 +159,18 @@ vi:
       image_valid_format:  "Hình ảnh phải có định dạng png, jpg, jpeg hoặc gif"
       less_than_5MB: "Hình ảnh phải nhỏ hơn 5MB"
       chose_other_image: "Vui lòng chọn hình ảnh khác"
+
+  relationships:
+    common:
+      user_not_found: "Người dùng không tồn tại"
+      relationship_not_found: "Mối quan hệ không tồn tại"
+
+  followers:
+    index:
+      title: "Người theo dõi"
+      followers: "Người theo dõi"
+  
+  followings:
+    index:
+      title: "Đang theo dõi"
+      following: "Đang theo dõi"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'followers/index'
+  get 'followings/index'
   constraints(locale: /en|vi/) do
     # Define your routes here
     # root define
@@ -12,6 +14,16 @@ Rails.application.routes.draw do
     resources :account_activations, only: :edit
     resources :password_resets, only: %i(new create edit update)
     resources :microposts, only: %i(create destroy)
+
+    resources :users do
+      member do
+        get :followings , to: "followings#index"
+        get :followers, to: "followers#index"
+      end
+    end
+
+
+    resources :relationships, only: %i(create destroy)
 
     get "/login", to: "sessions#new"
     post "/login", to: "sessions#create"

--- a/db/migrate/20230828122851_create_relationships.rb
+++ b/db/migrate/20230828122851_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_28_061709) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_28_122851) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -52,6 +52,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_28_061709) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "relationships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,12 @@ users = User.order(:created_at).take(6)
   content = "Noi dung #{n+1}"
   users.each { |user| user.microposts.create!(content: content) }
 end
+
+
+# Create following relationships.
+users = User.all
+user = users.first
+following = users[2..50]
+followers = users[3..40]
+following.each { |followed| user.follow(followed) }
+followers.each { |follower| follower.follow(user) }


### PR DESCRIPTION
- **so sánh rails ajax và jquery ajax ?**

   - Rails Ajax:

       - Cơ chế tích hợp: Rails cung cấp tích hợp sẵn với Ajax thông qua các hàm helper như remote_link_to, remote_form_for, và link_to với tùy chọn remote: true.
       - Phụ thuộc vào Unobtrusive JavaScript: Rails sử dụng Unobtrusive JavaScript để tách biệt mã JavaScript khỏi HTML. Điều này giúp duy trì mã nguồn dễ đọc và bảo trì hơn.
       - Tích hợp dễ dàng: Rails cung cấp cơ chế để xử lý các yêu cầu Ajax bằng cách định nghĩa các phương thức trong controller với đuôi .js.erb để render JavaScript kết hợp với dữ liệu.

   - jQuery Ajax:

       - Thư viện JavaScript bên thứ ba: jQuery là một thư viện JavaScript riêng biệt. Để sử dụng Ajax trong jQuery, bạn cần thêm jQuery vào dự án của mình.
       - Tùy chỉnh linh hoạt: jQuery Ajax cho phép bạn tùy chỉnh hoàn toàn cách bạn gửi yêu cầu Ajax và xử lý kết quả. Bạn có thể sử dụng các phương thức như $.ajax hoặc $.get để thực hiện yêu cầu.
       - Chuyên biệt hơn cho việc xử lý Ajax: jQuery là một thư viện chuyên biệt cho việc xử lý Ajax, nên nó cung cấp nhiều tùy chọn mạnh mẽ hơn để tùy chỉnh các yêu cầu và xử lý dữ liệu trả về.

- **so sánh member vs collection**

   - So sánh:

       - member routes làm việc với một tài nguyên cụ thể (dựa trên ID) và thường định nghĩa các hành động thực hiện trên tài nguyên đó.
       - collection routes làm việc với tất cả các tài nguyên trong một loạt tài nguyên và thường định nghĩa các hành động hoạt động trên toàn bộ tập hợp tài nguyên.
       - member routes thường làm việc với một tài nguyên cụ thể và yêu cầu ID trong URL.
       - collection routes thường làm việc với toàn bộ tập hợp tài nguyên và không cần ID trong URL.
       - Ví dụ về member route: /posts/:id/like
       - Ví dụ về collection route: /posts/popular

- **tại sao phải khai báo class_name, foreign_key khi khai báo association**

   - class_name:

       - Mặc định, Rails giả định rằng tên lớp liên quan sẽ dựa vào tên của association. Ví dụ: association belongs_to :user sẽ giả định liên quan đến lớp User.
       - Tuy nhiên, trong một số trường hợp, tên lớp thực tế không phù hợp với tên của association. Khi đó, bạn cần sử dụng tùy chọn class_name để chỉ định tên lớp mà association nên sử dụng.
       - Ví dụ, nếu bạn có một association với tên là author, nhưng tên lớp thực tế là Writer, bạn cần khai báo: belongs_to :author, class_name: 'Writer'.
   - foreign_key:

       - Mặc định, Rails giả định rằng foreign key (khóa ngoại) sẽ được tạo bằng cách thêm "_id" vào tên của association. Ví dụ: association belongs_to :user sẽ giả định foreign key là user_id.
       - Tuy nhiên, trong một số trường hợp, tên foreign key thực tế không phù hợp với quy ước này, hoặc bạn muốn sử dụng một tên khóa ngoại khác. Khi đó, bạn cần sử dụng tùy chọn foreign_key để chỉ định tên khóa ngoại mà association nên sử dụng.
       - Ví dụ, nếu bạn muốn sử dụng foreign key là author_id thay vì user_id cho association belongs_to :author, bạn cần khai báo: belongs_to :author, foreign_key: 'author_id'.

- **source có tác dụng gì ?**
   - :source trong Ruby on Rails cho phép bạn chỉ định tên của một quan hệ hoặc cột mà mối quan hệ nên tham chiếu đến, giúp bạn tùy chỉnh cách mà các mối quan hệ giữa các model hoạt động.

- có những loại dependent nào? nen sử dụng loại nào
    - :destroy: Khi một bản ghi gốc bị xóa, tất cả các bản ghi liên quan cũng sẽ bị xóa.

       - :delete: Tương tự như :destroy, nhưng không gọi các callback hoặc triggers của ActiveRecord mà chỉ xóa bản ghi trực tiếp từ cơ sở dữ liệu. Điều này có thể hữu ích nếu bạn muốn xóa một lượng lớn bản ghi mà không muốn gây tải nặng cho việc thực thi callback.

       - :nullify: Khi một bản ghi gốc bị xóa, tất cả các bản ghi liên quan sẽ được cập nhật để giá trị của cột ngoại tuyến của chúng được đặt thành NULL.

       - :restrict_with_exception: Khi bạn cố gắng xóa một bản ghi gốc, và có các bản ghi liên quan tồn tại, một ngoại lệ ActiveRecord::DeleteRestrictionError sẽ được ném.

       - :restrict_with_error: Tương tự như :restrict_with_exception, nhưng thay vì ném ngoại lệ, một lỗi sẽ được thêm vào bản ghi gốc và bạn có thể xử lý lỗi đó theo cách của riêng bạn.

       - Không có: Bạn cũng có thể không sử dụng tùy chọn dependent để kiểm soát hành vi liên quan. Trong trường hợp này, các bản ghi liên quan sẽ không bị ảnh hưởng khi bản gốc bị xóa. Điều này thường hữu ích trong các tình huống đặc biệt mà bạn muốn xử lý việc xóa bản ghi liên quan một cách riêng biệt.

       - Loại dependent nào nên được sử dụng phụ thuộc vào yêu cầu kinh doanh cụ thể và cách mà bạn muốn quản lý dữ liệu. Ví dụ, nếu bạn muốn xóa tất cả các bản ghi liên quan khi một bản ghi gốc bị xóa, thì :destroy có thể là sự lựa chọn phù hợp. Tuy nhiên, nếu bạn muốn chỉ đặt cột ngoại tuyến thành NULL khi xóa, thì :nullify có thể là lựa chọn tốt.